### PR TITLE
closes #7 feat(readme): Switched URLs from jqapi.ru to github.io

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -4,3 +4,4 @@
 * Ilya Baryshev (@coagulant)
 * Vitaly Sergeev
 * Arthur Budko (@arteg)
+* Alexander Malitsky (@amalitsky)

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-jqapi.ru
+futurecolors.github.io/jqapi.ru

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# jQuery API Cheatsheet
+# jQuery API Cheat Sheet
 
-Enjoy sigle-page jQuery API Cheatseet by [Future Colors].
+Enjoy single-page jQuery API Cheat Sheet by [Future Colors] and community.
 
-This repo is powering http://jqapi.ru site.
+This repo used to power jqapi.ru website, now served through https://futurecolors.github.io/jqapi.ru/
 
 Contributions are welcome.
 
@@ -12,7 +12,7 @@ Contributions are welcome.
 * easily printable
 * clean design with less noise
 
-[![jQuery API Cheatsheet](https://raw.github.com/futurecolors/jqapi.ru/master/jquery_cheatsheet.png "screenshot")](http://jqapi.ru)
+[![jQuery API Cheatsheet](https://raw.github.com/futurecolors/jqapi.ru/master/jquery_cheatsheet.png "screenshot")](https://futurecolors.github.io/jqapi.ru/)
 
 ## Developing
 
@@ -21,7 +21,7 @@ Contributions are welcome.
 * `npm install`
 * `grunt`
 
-Now you have fresh build of cheatsheet in `build` folder.
+Now you have fresh build of cheat sheet in `build` folder.
 
 ### Tasks
 
@@ -29,6 +29,6 @@ Now you have fresh build of cheatsheet in `build` folder.
 Same as grunt, but also launches local server to display html.
 
     grunt publish
-Update jqapi.ru with latest build.
+Update https://futurecolors.github.io/jqapi.ru/ with latest build.
 
 [Future Colors]: http://futurecolors.ru

--- a/src/data/cheatsheet.json
+++ b/src/data/cheatsheet.json
@@ -2,6 +2,6 @@
     "title": "jQuery 1.8 API Cheat Sheet",
     "phone": "+7 495 649-32-49",
     "email": "info@futurecolors.ru",
-    "url": "jqapi.ru",
+    "url": "futurecolors.github.io/jqapi.ru",
     "logo_url": "http://futurecolors.ru"
 }

--- a/src/templates/cheatsheet.html
+++ b/src/templates/cheatsheet.html
@@ -62,7 +62,7 @@
         <div class="g-clear"></div>
 
         <div class="copyright_link">
-            <a href="http://{{cheatsheet.url}}"><span>http://</span>{{cheatsheet.url}}</a>
+            <a href="https://{{cheatsheet.url}}"><span>https://</span>{{cheatsheet.url}}</a>
            <h3>ver. {{now "%d.%m.%Y"}}</h3>
         </div>
     </div>

--- a/src/templates/partials/custom-buttons.html
+++ b/src/templates/partials/custom-buttons.html
@@ -1,5 +1,5 @@
 <div class="custom-buttons">
-    <ul class="social-likes" data-url="http://jqapi.ru" data-title="jQuery API Cheatsheet">
+    <ul class="social-likes" data-url="https://futurecolors.github.io/jqapi.ru/" data-title="jQuery API Cheat Sheet">
         <li class="facebook" title="Share link on Facebook">Facebook</li>
         <li class="twitter" data-via="futurecolors" title="Share link on Twitter">Twitter</li>
         <li class="plusone" title="Share link on Google+">Google+</li>


### PR DESCRIPTION
Guys, before merging this PR please update repo settings to drop jqapi.ru as a project URL.
Otherwise new futurecolors.github.io/jqapi.ru URL won't work.
[How to](https://help.github.com/articles/adding-or-removing-a-custom-domain-for-your-github-pages-site/)